### PR TITLE
CI: Switch to check-jsonschema

### DIFF
--- a/.github/workflows/json-checks.yml
+++ b/.github/workflows/json-checks.yml
@@ -26,7 +26,7 @@ jobs:
     needs: syntax
     steps:
       - uses: actions/checkout@v3
-      - name: install-jsonschema
-        run: pip3 install jsonschema
-      - name: json-schema-check
-        run: jsonschema --instance sopel_waifu/waifu.json sopel_waifu/waifu.json.schema
+      - name: install-deps
+        run: pip3 install check-jsonschema
+      - name: check-json-schema
+        run: check-jsonschema --schemafile sopel_waifu/waifu.json.schema sopel_waifu/waifu.json

--- a/sopel_waifu/waifu.json
+++ b/sopel_waifu/waifu.json
@@ -2581,6 +2581,12 @@
         "Kuga Machi",
         "Morikuni Momoka"
     ],
+    "Otonari no Tenshi-sama ni Itsunomanika Dame Ningen ni Sareteita Ken": [
+        "Shiina \"Angel\" Mahiru",
+        "Shirakawa Chitose",
+        "Fujimiya Shihoko",
+        "Shiina Sayo"
+    ],
     "Overlord": [
         "Albedo",
         "Yuri Alpha",


### PR DESCRIPTION
Apparently an old version (3.x) of jsonschema is preinstalled on the GitHub Actions system image for ubuntu-20.04, but the 4.x series has deprecated its CLI in favor of a separate package.

Bundled adding a show('s cast) because the workflow only triggers on changes to `*.json` files.