### PR TITLE
Zenless Zone Zero update 1.2

### DIFF
--- a/sopel_waifu/waifu.json
+++ b/sopel_waifu/waifu.json
@@ -7416,16 +7416,25 @@
     ],
     "Zenless Zone Zero": [
         "Belle",
+
         "Anby Demara",
-        "Corin Wickes",
-        "Ellen Joe",
-        "Grace Howard",
-        "Koleda Belobog",
-        "Nekomiya \"Nekomata\" Mana",
         "Nicole Demara",
-        "Alexandrina \"Rina\" Sebastiane",
+        "Nekomiya \"Nekomata\" Mana",
         "Soldier 11",
+        "Corin Wickes",
+        "Koleda Belobog",
+        "Grace Howard",
+        "Ellen Joe",
+        "Alexandrina \"Rina\" Sebastiane",
+        "Zhu Yuan",
         "Soukaku",
+        "Luciana de Montefio",
+        "Piper Wheel",
+        "Qingyi",
+        "Jane Doe",
+        "Caesar",
+        "Burnice White",
+
         "Hoshimi Miyabi"
     ],
     "Zero no Tsukaima": [

--- a/sopel_waifu/waifu.json
+++ b/sopel_waifu/waifu.json
@@ -7432,7 +7432,7 @@
         "Piper Wheel",
         "Qingyi",
         "Jane Doe",
-        "Caesar",
+        "Caesar King",
         "Burnice White",
 
         "Hoshimi Miyabi"


### PR DESCRIPTION
Started using HoyoWiki at https://wiki.hoyolab.com/pc/zzz/aggregate/8 for these, and will probably also convert/update Genshin + Star Rail using that source too. Ordered the characters to match their sorting.

Characters are also now grouped so hopefully I'll remember the special exceptions: Belle is the female playable character, so she's separated; Hoshimi Miyabi is left in the list, also separated, despite HoyoWiki not listing her, since I have it on good authority that she's coming to the game but just not announced officially yet.

Hopefully organizing a bit makes it easier to maintain the Hoyo games. And I still wish JSON allowed for comments...