### PR TITLE
Overhaul automation and add whitespace checks

### DIFF
--- a/.github/workflows/json-checks.yml
+++ b/.github/workflows/json-checks.yml
@@ -29,7 +29,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: check-keys
-        run: python3 duplicate_detect.py sopel_waifu/waifu.json
+        run: make duplicates
   schema:
     name: Validate JSON schema
     runs-on: ubuntu-22.04
@@ -37,6 +37,16 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: install-deps
-        run: pip3 install check-jsonschema
+        run: make schema-check-deps
       - name: check-json-schema
-        run: check-jsonschema --schemafile sopel_waifu/waifu.json.schema sopel_waifu/waifu.json
+        run: make schema-check
+  whitespace:
+    name: "Check for whitespace errors"
+    runs-on: ubuntu-22.04
+    needs: syntax
+    steps:
+      - uses: actions/checkout@v4
+      - name: install-deps
+        run: make whitespace-deps
+      - name: check-whitespace
+        run: make whitespace

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,36 @@
-.PHONY: quality
-quality:
-	python3 duplicate_detect.py sopel_waifu/waifu.json
-	check-jsonschema --schemafile sopel_waifu/waifu.json.schema sopel_waifu/waifu.json
+.DEFAULT_GOAL := lint
+.PHONY: dev install install-dev lint duplicates schema-check schema-check-deps whitespace whitespace-deps
+
+dev: schema-check-deps whitespace-deps install-dev
+
+install:
+	pip install -U .
+
+install-dev:
+	pip install -U -e .
+
+lint: whitespace duplicates schema-check
+
+duplicates:
+	@echo "🎯 Running duplicate_detect script"
+	@python3 scripts/duplicate_detect.py sopel_waifu/waifu.json
+	@echo ""
+
+schema-check:
+	@echo "🎯 Running check-jsonschema"
+	@check-jsonschema --schemafile sopel_waifu/waifu.json.schema sopel_waifu/waifu.json
+	@echo ""
+
+schema-check-deps:
+	pip3 install -U check-jsonschema
+
+whitespace:
+	@echo "🎯 Running whitespace-format"
+	@whitespace-format --check-only --add-new-line-marker-at-end-of-file \
+	--new-line-marker auto --normalize-new-line-markers \
+	--replace-tabs-with-spaces 4 --remove-trailing-empty-lines \
+	--remove-trailing-whitespace sopel_waifu/waifu.json
+	@echo ""
+
+whitespace-deps:
+	pip3 install -U whitespace-format

--- a/scripts/duplicate_detect.py
+++ b/scripts/duplicate_detect.py
@@ -30,8 +30,8 @@ with open(sys.argv[1]) as f:
     try:
         json.load(f, object_pairs_hook=validate_data)
     except ValueError as exc:
-        print("❌ {err}".format(err=exc))
+        print("{err} ❌".format(err=exc))
         sys.exit(1)
     else:
-        print("✅ No duplicate keys detected!")
+        print("No duplicate keys detected! ✅")
         sys.exit(0)


### PR DESCRIPTION
First things first: Now using `whitespace-format` from PyPI to check for whitespace errors in `waifu.json`. This check has been added to the CI workflow too. The other three validation tasks are all allowed to start in parallel once syntax checking passes.

Trying to take much better advantage of the Makefile, it's now usable to both set up a local development environment AND be called from within GitHub Actions to set up requirements for each task.